### PR TITLE
swap Thai bhat ฿ to BTC symbol ₿

### DIFF
--- a/raspibolt-pulse-switch.sh
+++ b/raspibolt-pulse-switch.sh
@@ -29,6 +29,7 @@ color_red='\033[0;31m'
 color_green='\033[0;32m'
 color_yellow='\033[0;33m'
 color_grey='\033[0;37m'
+color_orange='\033[38;5;208m'
 
 # controlled abort on Ctrl-C
 trap_ctrlC() {
@@ -65,7 +66,7 @@ fi
 # Print first welcome message
 # ------------------------------------------------------------------------------
 printf "
-${color_yellow}RaspiBolt %s:${color_grey} Sovereign Bitcoin full node
+${color_yellow}RaspiBolt %s:${color_grey} Sovereign \033[1m"₿"\033[22mitcoin full node
 ${color_yellow}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 " "3"
 
@@ -216,7 +217,7 @@ else
 fi
 btc_path=$(command -v bitcoin-cli)
 if [ -n "${btc_path}" ]; then
-  btc_title="฿itcoin"
+  btc_title="itcoin"
   chain="$(bitcoin-cli -datadir=${bitcoin_dir} getblockchaininfo | jq -r '.chain')"
 
   btc_title="${btc_title} (${chain}net)"
@@ -393,10 +394,10 @@ echo -ne "\033[2K"
 printf "${color_grey}cpu temp: ${color_temp}%-2s°C${color_grey}  tx: %-10s storage:   ${color_storage}%-11s ${color_grey}  load: %s
 ${color_grey}up: %-10s  rx: %-10s 2nd drive: ${color_storage2nd}%-11s${color_grey}   available mem: ${color_ram}%sM
 ${color_yellow}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-${color_green}     .~~.   .~~.      ${color_yellow}%-22s${bitcoind_color}%-4s${color_grey}   ${color_yellow}%-20s${ln_color}%-4s
+${color_green}     .~~.   .~~.      ${color_yellow}\033[1m"₿"\033[22m%-19s${bitcoind_color}%-4s${color_grey}   ${color_yellow}%-20s${lnd_color}%-4s
 ${color_green}    '. \ ' ' / .'     ${btcversion_color}%-26s ${ln_version_color}%-24s
 ${color_red}     .~ .~~~${color_yellow}.${color_red}.~.      ${color_grey}Sync    ${sync_color}%-18s ${alias_color}%-24s
-${color_red}    : .~.'${color_yellow}／/${color_red}~. :     ${color_grey}Mempool %-18s ${color_grey}฿%17s sat
+${color_red}    : .~.'${color_yellow}／/${color_red}~. :     ${color_grey}Mempool %-18s ${color_orange}\033[1m"₿"\033[22m${color_grey}%17s sat
 ${color_red}   ~ (  ${color_yellow}／ /_____${color_red}~    ${color_grey}Peers   %-22s ${color_grey}⚡%16s sat
 ${color_red}  ( : ${color_yellow}／____   ／${color_red} )                              ${color_grey}⏳%16s sat
 ${color_red}   ~ .~ (  ${color_yellow}/ ／${color_red}. ~    ${color_yellow}%-20s${electrs_color}%-4s   ${color_grey}∑%17s sat


### PR DESCRIPTION
Why? because it's Bitcoin, not Thai fiat.
And it's Orange!
₿
<img width="480" alt="188533744-0f7e5a9c-56f7-45ba-b0bf-1826ced9a2a2" src="https://user-images.githubusercontent.com/94819106/193720926-d6b0551c-a9d8-47f7-a33e-080d342239d2.png">

Fixes #4 

Line by line explanation:

line 32 defines the color orange based on the "256 colors table" from this document https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797 
line 69 changes a B to a ₿ in the "Sovriegn Bitcoin full node"
line 220 loses the ฿ from the beginning of the word in order to add it back later 
line 397 adds back the ₿ to the "itcoin" (had to do this because adding it to the original variable on line 220 for some reason didn't reproduce properly) 
line 400 switches the existing ฿ for an orange ₿