### PR TITLE
Improve performance by reduced calls and timeouts

### DIFF
--- a/get_CLN_data.sh
+++ b/get_CLN_data.sh
@@ -37,7 +37,7 @@ ln_walletbalance=0
 #check if len(outputs) == 0 --> empty wallet
 amount_of_wallet_transactions=$(echo ${lncli_listfunds} | jq -r '.outputs | length')
 if [ $amount_of_wallet_transactions -gt 0 ];then
-ln_walletbalance=$(echo ${lncli_listfunds) | jq -r '.outputs[0].value | tonumber')
+ln_walletbalance=$(echo ${lncli_listfunds} | jq -r '.outputs[0].value | tonumber')
 fi
 
 ## Show channel balance

--- a/get_LND_data.sh
+++ b/get_LND_data.sh
@@ -6,7 +6,11 @@ ln_git_version=$4
 
 echo -ne '\r### Loading LND data \r'
 
-lnd_dir="/data/lnd"
+# set datadir
+lnd_dir="/mnt/ext/lnd"      # Raspibolt 1.x, 2.x
+if [ -d "/data/lnd" ]; then
+  lnd_dir="/data/lnd"       # Raspibolt 3.x
+fi
 
 if [ "${chain}" = "test" ]; then
   macaroon_path="${lnd_dir}/data/chain/bitcoin/testnet/readonly.macaroon"
@@ -33,7 +37,7 @@ if [ -z "${lnd_running##*up*}" ] ; then
 else
   wallet_unlocked=0
 fi
-printf "%0.s#" {1..63}
+printf "%0.s#" {1..40}
 echo -ne '\r### Loading LND data \r'
 
 if [ "$wallet_unlocked" -eq "0" ] ; then
@@ -56,43 +60,52 @@ if [ "$wallet_unlocked" -eq "0" ] ; then
     ln_connect_guidance="The LND service is down. Start the service:   sudo systemctl start lnd"
   fi
 else
+  # Reduce number of calls to LND by doing once and caching
+  lncli_channelbalance=$(${lncli} channelbalance)
+  lncli_getinfo=$(${lncli} getinfo)
+  lncli_listchannels=$(${lncli} listchannels)
+  lncli_pendingchannels=$(${lncli} pendingchannels)
+  lncli_walletbalance=$(${lncli} walletbalance)
+
   alias_color="${color_grey}"
-  ln_alias="$(${lncli} getinfo | jq -r '.alias')" 2>/dev/null
-  ln_walletbalance="$(${lncli} walletbalance | jq -r '.confirmed_balance')" 2>/dev/null
-  ln_channelbalance="$(${lncli} channelbalance | jq -r '.balance')" 2>/dev/null
+  ln_alias="$(echo ${lncli_getinfo} | jq -r '.alias')" 2>/dev/null
+  ln_walletbalance="$(echo ${lncli_walletbalance} | jq -r '.confirmed_balance')" 2>/dev/null
+  ln_channelbalance="$(echo ${lncli_channelbalance} | jq -r '.balance')" 2>/dev/null
 
-  printf "%0.s#" {1..66}
+  printf "%0.s#" {1..46}
 
-  echo -ne '\r### Loading LND data \r'
+  echo -ne '\r### Loading LND data - connect info \r'
 
-  ln_channels_online="$(${lncli} getinfo | jq -r '.num_active_channels')" 2>/dev/null
-  ln_channels_total="$(${lncli} listchannels | jq '.[] | length')" 2>/dev/null
-  ln_connect_addr="$(${lncli} getinfo | jq -r '.uris[0]')" 2>/dev/null
+  ln_channels_online="$(echo ${lncli_getinfo} | jq -r '.num_active_channels')" 2>/dev/null
+  ln_channels_total="$(echo ${lncli_listchannels} | jq '.[] | length')" 2>/dev/null
+  ln_connect_addr="$(echo ${lncli_getinfo} | jq -r '.uris[0]')" 2>/dev/null
   ln_connect_guidance="lncli connect ${ln_connect_addr}"
-  ln_external="$(echo "${ln_connect_addr}" | tr "@" " " |  awk '{ print $2 }')" 2>/dev/null
-  if [ -z "${ln_external##*onion*}" ]; then
+  if [ -z "${ln_connect_addr##*onion*}" ]; then
     ln_external="Using TOR Address"
+  else
+    ln_external="Using Clearnet"
   fi
 
-  printf "%0.s#" {1..70}
-  echo -ne '\r### Loading LND data \r'
+  printf "%0.s#" {1..52}
+  echo -ne '\r### Loading LND data - pending channels \r'
 
-  ln_pendingopen=$($lncli pendingchannels  | jq '.pending_open_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
+  ln_pendingopen=$(echo ${lncli_pendingchannels} | jq '.pending_open_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
   if [ -z "${ln_pendingopen}" ]; then
     ln_pendingopen=0
   fi
 
-  ln_pendingforce=$($lncli pendingchannels  | jq '.pending_force_closing_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
+  ln_pendingforce=$(echo ${lncli_pendingchannels} | jq '.pending_force_closing_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
   if [ -z "${ln_pendingforce}" ]; then
     ln_pendingforce=0
   fi
 
-  ln_waitingclose=$($lncli pendingchannels  | jq '.waiting_close_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
+  ln_waitingclose=$(echo ${lncli_pendingchannels} | jq '.waiting_close_channels[].channel.local_balance|tonumber ' | awk '{sum+=$0} END{print sum}')
   if [ -z "${ln_waitingclose}" ]; then
     ln_waitingclose=0
   fi
 
-  echo -ne '\r### Loading LND data \r'
+  printf "%0.s#" {1..58}
+  echo -ne '\r### Loading LND data - summary \r'
 
   ln_pendinglocal=$((ln_pendingopen + ln_pendingforce + ln_waitingclose))
 
@@ -108,6 +121,9 @@ else
   fi
 fi
 
+printf "%0.s#" {1..64}
+echo -ne '\r### Determining version \r'
+
 #create variable lndversion
 lndpi=$(lncli getinfo | sed -n 's/^\(.*\)=\(.\+\?\)"\(.*\)/\2/p')
 if [ "${lndpi}" = "${ln_git_version}" ]; then
@@ -118,13 +134,19 @@ else
   lndversion_color="${color_red}"
 fi
 
+printf "%0.s#" {1..70}
+echo -ne '\r### Determining channel db size \r'
+
 #get channel.db size
 ln_channel_db_size=$(du -h ${lnd_dir}/data/graph/mainnet/channel.db | awk '{print $1}')
+
+printf "%0.s#" {1..76}
+echo -ne '\r### Saving \r'
 
 # Write to JSON file
 lnd_infofile="${HOME}/.raspibolt.lndata.json"
 lnd_color=$(echo $lnd_color | sed 's/\\/\\\\/g')
 lndversion_color=$(echo $lndversion_color | sed 's/\\/\\\\/g')
 alias_color=$(echo $alias_color| sed 's/\\/\\\\/g')
-printf '{"ln_running":"%s","ln_version":"%s","ln_walletbalance":"%s","ln_channelbalance":"%s","ln_pendinglocal":"%s","ln_sum_balance":"%s","ln_channels_online":"%s","ln_channels_total":"%s","ln_channel_db_size":"%s","ln_color":"%s","ln_version_color":"%s","alias_color":"%s","ln_alias":"%s","ln_connect_guidance":"%s"}' "\
-$lnd_running" "$lndversion" "$ln_walletbalance" "$ln_channelbalance" "$ln_pendinglocal" "$ln_sum_balance" "$ln_channels_online" "$ln_channels_total" "$ln_channel_db_size" "$lnd_color" "$lndversion_color" "$alias_color" "$ln_alias" "$ln_connect_guidance" > $lnd_infofile
+printf '{"ln_running":"%s","ln_version":"%s","ln_version_available":"%s","ln_walletbalance":"%s","ln_channelbalance":"%s","ln_pendinglocal":"%s","ln_sum_balance":"%s","ln_channels_online":"%s","ln_channels_total":"%s","ln_channel_db_size":"%s","ln_color":"%s","ln_version_color":"%s","alias_color":"%s","ln_alias":"%s","ln_connect_guidance":"%s"}' "\
+$lnd_running" "$lndversion" "$ln_git_version" "$ln_walletbalance" "$ln_channelbalance" "$ln_pendinglocal" "$ln_sum_balance" "$ln_channels_online" "$ln_channels_total" "$ln_channel_db_size" "$lnd_color" "$lndversion_color" "$alias_color" "$ln_alias" "$ln_connect_guidance" > $lnd_infofile


### PR DESCRIPTION
- JSONify raspibolt versions from github
- Normalize all calls to github to use releases instead of tags, and jq for parsing
- Reduce calls to bitcoin-cli, lncli, and lightning-cli to improve performance
- Add connect timeouts to curl commands to improve performance
- Fix lnd_color issue in output and switch back to grey color when appropriate
- Support Raspibolt 2.x and 3.x