### PR TITLE
Add random Bitcoin quote

### DIFF
--- a/raspibolt-pulse-switch.sh
+++ b/raspibolt-pulse-switch.sh
@@ -197,6 +197,12 @@ fi
 network_rx=$(ip -j -s link show | jq '.[] | [(select(.ifname!="lo") | .stats64.rx.bytes)//0] | add' | awk -v OFMT='%.0f' '{sum+=$0} END{print sum}' | numfmt --to=iec)
 network_tx=$(ip -j -s link show | jq '.[] | [(select(.ifname!="lo") | .stats64.tx.bytes)//0] | add' | awk -v OFMT='%.0f' '{sum+=$0} END{print sum}' | numfmt --to=iec)
 
+# get local network ip address
+local_ip=$(ip addr show | grep -w inet | grep -v 127.0.0.1 | awk '{print $2}' | cut -d/ -f1)
+local_hostname=$(hostname)
+
+
+
 # Gather application versions
 # ------------------------------------------------------------------------------
 gitstatusfile="${HOME}/.raspibolt.versions.json"
@@ -716,7 +722,7 @@ fi
 echo -ne "\033[2K"
 printf "${color_grey}cpu temp: ${color_temp}%-4s${color_grey}  tx: %-10s storage:   ${color_storage}%-11s ${color_grey}  load: %s${color_grey}
 ${color_grey}up: %-10s  rx: %-10s 2nd drive: ${color_storage2nd}%-11s${color_grey}   available mem: ${color_ram}%sM${color_grey}
-${color_grey}updates: ${color_updates}%-21s${color_grey}
+${color_grey}updates: ${color_updates}%-21s${color_grey} ip addr: %-15s hostname: %-20s
 ${color_yellow}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${color_grey}
 ${color_green}     .~~.   .~~.      ${color_orange}"₿"${color_yellow}%-19s${bitcoind_color}%-4s${color_grey}   ${color_yellow}%-20s${lserver_color}%-4s${color_grey}
 ${color_green}    '. \ ' ' / .'     ${btcversion_color}%-26s ${lserver_version_color}%-24s${color_grey}
@@ -736,7 +742,7 @@ ${color_grey}%s
 " \
 "${temp}" "${network_tx}" "${storage} free" "${load}" \
 "${uptime}" "${network_rx}" "${storage2nd}" "${ram_avail}" \
-"${updates}" \
+"${updates}" "${local_ip}" "${local_hostname}" \
 "${btc_title}" "${bitcoind_running}" "${lserver_label}" "${lserver_running}" \
 "${btcversion}" "${lserver_version}" \
 "${sync} ${sync_behind}" \

--- a/raspibolt-pulse-switch.sh
+++ b/raspibolt-pulse-switch.sh
@@ -365,7 +365,7 @@ if [ -n "${btc_path}" ]; then
       btcversion_color="${color_green}"
       ;;
     *)
-      btcversion="$btcpi"" Update!"
+      btcversion="${btcpi} to ${btcgit}"
       btcversion_color="${color_red}"
       ;;
   esac
@@ -591,7 +591,7 @@ if [ "$electrs_status" = "enabled" ]; then
       eserver_version="$electrspi"
       eserver_version_color="${color_green}"
     else
-      eserver_version="$electrspi"" Update!"
+      eserver_version="${electrspi} to ${electrsgit}"
     fi
   fi
 # Fulcrum specific
@@ -608,7 +608,7 @@ elif [ "$fulcrum_status" = "enabled" ];  then
       eserver_version="$fulcrumpi"
       eserver_version_color="${color_green}"
     else
-      eserver_version="$fulcrumpi"" Update!"
+      eserver_version="${fulcrumpi} to ${fulcrumgit}"
     fi
   fi
 # ... add any future supported electrum server implementation checks here
@@ -645,7 +645,7 @@ if [ "$btcrpcexplorer_status" = "enabled" ]; then
       bserver_version="$btcrpcexplorerpi"
       bserver_version_color="${color_green}"
     else
-      bserver_version="$btcrpcexplorerpi"" Update!"
+      bserver_version="${btcrpcexplorerpi} to ${btcrpcexplorergit}"
     fi
   fi
 # ... add any future supported blockchain explorer implementation checks here
@@ -688,7 +688,7 @@ if [ "$rtl_status" = "enabled" ]; then
       lwserver_version="$rtlpi"
       lwserver_version_color="${color_green}"
     else
-      lwserver_version="$rtlpi"" Update!"
+      lwserver_version="${rtlpi} to ${rtlgit}"
     fi
   fi
 # Thunderhub specific
@@ -706,7 +706,7 @@ elif [ "$thunderhub_status" = "enabled" ]; then
       lwserver_version="$thunderhubpi"
       lwserver_version_color="${color_green}"
     else
-      lwserver_version="$thunderhubpi"" Update!"
+      lwserver_version="${thunderhubpi} to ${thunderhubgit}"
     fi
   fi
 # ... add any future supported lightning web app implementation checks here
@@ -747,7 +747,7 @@ ${color_grey}%s
 "${btcversion}" "${lserver_version}" \
 "${sync} ${sync_behind}" \
 "${mempool} tx" \
-"${connections} (📥${inbound} /📤${outbound})"  \
+"${connections} (📥${inbound}/📤${outbound})"  \
 "${eserver_label}" "${eserver_running}" \
 "${eserver_version}" \
 "${bserver_label}" "${bserver_running}" \


### PR DESCRIPTION
Implemented feature request "Add a Bitcoin quote taken from the local BTC RPC Explorer API" (#7). Displaying the quote is controlled by passing the quote option (--quote or -q).

The change also supports multiple options, e.g. quote and mock. Another cool feature is that the quote is wrapped, so that long quotes do not run of screen and stay within the borders (max line length 78 characters).

To display the quote correctly required a hack as bash does not preserve trailing new lines.

Resolves: [#7](https://github.com/raspibolt/raspibolt-pulse/issues/7)

This is an example with quote:

![quote](https://github.com/raspibolt/raspibolt-pulse/assets/96747748/d4f6d9b4-e2ca-4403-89e8-bfa116b303a0)